### PR TITLE
[FIX] delete.js에서 postSaving에 docId 아닌 id로 전달

### DIFF
--- a/js/delete.js
+++ b/js/delete.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const id = pathname.split('/').pop();
       console.log('path : ', id);
 
-      postSaving(docId);
+      postSaving(id);
     } catch (error) {
       console.error('데이터 가져오기 실패:', error);
     }


### PR DESCRIPTION
## CHANGES
delete.js에서 postSaving에 docId 아닌 id로 전달합니다.

## Screen Shot

## Related Issue
