### PR TITLE
[FEAT] 하위 파일은 루트에서 3개까지만 추가 가능

### DIFF
--- a/js/show.js
+++ b/js/show.js
@@ -80,6 +80,11 @@ function showDocuments(doc, depth) {
   addDocumentBtn.addEventListener('click', (event) => {
     event.stopPropagation();
     // postDocument(doc.id);
+    // console.log(depth);
+    if (depth >= 3) {
+      alert('하위 문서는 3개까지만 추가 가능해요🥲');
+      return;
+    }
     postDocuments(doc.id);
     getDocuments();
     //fetchDocument(doc.id);


### PR DESCRIPTION
## CHANGES
하위 파일은 루트 기준으로 3개까지만 추가 가능하도록 수정했습니다. 즉 depth0, depth1, depth2, depth3 까지 가능합니다.

## Screen Shot
3개 보다 더 추가하려고 할 시 에러 발생 후 추가되지 않음.
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/c8acef8e-66d0-40c2-8aac-80a726f26f85" />

## Related Issue
